### PR TITLE
feat: hanspell 맞춤법 검사 api 함수 작성

### DIFF
--- a/api.js
+++ b/api.js
@@ -1,0 +1,42 @@
+import hanspell from 'hanspell';
+
+async function checkSpell(sentence) {
+  const TIMEOUT_MS = 6000;
+  const lastToken = getLastToken(sentence);
+
+  return new Promise((resolve, reject) => {
+    hanspell.spellCheckByPNU(
+      lastToken,
+      TIMEOUT_MS,
+      (res) => resolve(returnRes(res)),
+      (err) => reject(returnErr(err))
+    );
+  });
+}
+
+function getLastToken(sentence) {
+  const tokens = sentence.trim().split(' ');
+  return tokens[tokens.length - 1];
+}
+
+function returnRes(res) {
+  if (res.length === 0) {
+    return {
+      token: '',
+      suggestions: [],
+    };
+  } else {
+    return {
+      token: res[0].token,
+      suggestions: res[0].suggestions,
+    };
+  }
+}
+
+function returnErr(err) {
+  return {
+    error: err,
+  };
+}
+
+export default checkSpell;


### PR DESCRIPTION

close #1

haspell을 이용한 맞춤법 검사 api 함수 코드를 작성했습니다.
returnRes, returnErr의 정상 및 에러 응답 포맷 확인해 주시고 불편한 점 있으면 말씀주세요!

함수 사용법은 아래와 같습니다.
```
import checkSpell from './api.js';
```
